### PR TITLE
Changed win blocking to ignore jesters

### DIFF
--- a/lua/randomat2/events/christmascheer.lua
+++ b/lua/randomat2/events/christmascheer.lua
@@ -96,7 +96,7 @@ function EVENT:Begin()
             if v:Alive() and v:IsTerror() then
                 if v:IsRole(ROLE_ELF) then
                     elf_alive = true
-                else
+                elseif not v:ShouldActLikeJester() then
                     other_alive = true
                 end
             end


### PR DESCRIPTION
This fixes the clowns not activating and the round not ending
The side effect is other jester team members don't need to be converted for the Elf to win the round, but I think that's acceptable